### PR TITLE
Introduce new Tokenista::validate method and result object

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+## 1.3.0 (2019-12-10)
+
+* [DEPRECATION] Deprecate the `isExpired`, `isValid` and `isTampered` methods on 
+  Tokenista itself in favour of using the new `validate` method to get a more fully
+  -formed result.
 * Introduce new Tokenista::validate method and a validation result object to simplify
   flows where the handling of an invalid token is the same but you want to e.g. log an
   expired token differently to a tampered one.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 
+* Introduce new Tokenista::validate method and a validation result object to simplify
+  flows where the handling of an invalid token is the same but you want to e.g. log an
+  expired token differently to a tampered one.
+
 ## 1.2.0 (2019-04-03)
 
 * Drop support for php5 and test on php7

--- a/src/Ingenerator/TokenistaValidationResult.php
+++ b/src/Ingenerator/TokenistaValidationResult.php
@@ -1,0 +1,68 @@
+<?php
+
+
+namespace Ingenerator;
+
+
+class TokenistaValidationResult
+{
+    const INVALID_EXPIRED  = 'expired';
+    const INVALID_TAMPERED = 'tampered';
+    const VALID            = 'valid';
+
+    /**
+     * @var bool[]
+     */
+    private $errors = [];
+
+    /**
+     * @var \DateTimeImmutable
+     */
+    private $token_expiry;
+
+    public function __construct(array $check_status, int $expiry_ts)
+    {
+        $this->errors       = array_filter($check_status);
+        $this->token_expiry = (new \DateTimeImmutable)->setTimestamp($expiry_ts);
+    }
+
+    /**
+     * Mostly used to check why a token is invalid
+     *
+     * Returns `valid` for a valid token, or a comma-separated list of failure codes if the token is invalid. This
+     * is commonly used to allow app logic to have a single branch for an invalid token, but to set e.g. a log level
+     * or user response differently if it's just that the token has expired rather than that the signature is incorrect
+     * or the value corrupt/tampered.
+     *
+     * @return string
+     */
+    public function getStatusCodes(): string
+    {
+        if (empty($this->errors)) {
+            return static::VALID;
+        }
+
+        return implode(',', array_keys($this->errors));
+    }
+
+    public function getTokenExpiry(): \DateTimeImmutable
+    {
+        return $this->token_expiry;
+    }
+
+    public function isExpired(): bool
+    {
+        return $this->errors[static::INVALID_EXPIRED] ?? FALSE;
+    }
+
+    public function isTampered(): bool
+    {
+        return $this->errors[static::INVALID_TAMPERED] ?? FALSE;
+    }
+
+    public function isValid(): bool
+    {
+        return empty($this->errors);
+    }
+
+}


### PR DESCRIPTION
To simplify cases where you want to have a single logic branch
for all invalid tokens, but to be able to tweak logging or user
feedback depending on why the token failed validation - for example
to treat an expired token as less severe than a tampered one.